### PR TITLE
Remove destination dir before install.

### DIFF
--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -30,6 +30,11 @@ if ! command -v git 1>/dev/null 2>&1; then
   exit 1
 fi
 
+if [ -d "$PYENV_ROOT" ]; then
+    printf '%s\n' "Removing Lock ($PYENV_ROOT)"
+    rm -rf "$PYENV_ROOT"
+fi
+
 checkout "git://github.com/yyuu/pyenv.git"            "${PYENV_ROOT}"
 checkout "git://github.com/yyuu/pyenv-doctor.git"     "${PYENV_ROOT}/plugins/pyenv-doctor"
 checkout "git://github.com/yyuu/pyenv-installer.git"  "${PYENV_ROOT}/plugins/pyenv-installer"


### PR DESCRIPTION
If PYENV_ROOT exist you cannot make git clone  in this dir 
```
 checkout "git://github.com/yyuu/pyenv.git"            "${PYENV_ROOT}"
```
```
fatal: destination path '/pyenv' already exists and is not an empty directory.
```