### PR TITLE
use $PYENV_ROOT to produce correct "how to set $PATH" message

### DIFF
--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -72,14 +72,16 @@ if ! command -v pyenv 1>/dev/null; then
   { echo "# Load pyenv automatically by adding"
     echo "# the following to ${profile}:"
     echo
+    pyenv_bin=${PYENV_ROOT-$HOME}/bin
+    pyenv_bin=${pyenv_bin/$HOME/'$HOME'}
     case "$shell" in
     fish )
-      echo "set -x PATH \"\$HOME/.pyenv/bin\" \$PATH"
+      echo "set -x PATH \"$pyenv_bin\" \$PATH"
       echo 'status --is-interactive; and . (pyenv init -|psub)'
       echo 'status --is-interactive; and . (pyenv virtualenv-init -|psub)'
       ;;
     * )
-      echo "export PATH=\"\$HOME/.pyenv/bin:\$PATH\""
+      echo "export PATH=\"$pyenv_bin:\$PATH\""
       echo "eval \"\$(pyenv init -)\""
       echo "eval \"\$(pyenv virtualenv-init -)\""
       ;;

--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -72,7 +72,7 @@ if ! command -v pyenv 1>/dev/null; then
   { echo "# Load pyenv automatically by adding"
     echo "# the following to ${profile}:"
     echo
-    pyenv_bin=${PYENV_ROOT-$HOME}/bin
+    pyenv_bin=${PYENV_ROOT-$HOME/.pyenv}/bin
     pyenv_bin=${pyenv_bin/$HOME/'$HOME'}
     case "$shell" in
     fish )


### PR DESCRIPTION
The existing prompt to edit the user's shell profile assumes $PYENV_ROOT is $HOME/.pyenv. This pull request uses $PYENV_ROOT to produce a correct help output, and also substitutes $HOME If appropriate, e.g. PYENV_ROOT=~/anything will output $HOME/anything.