### PR TITLE
Use shallow clone for repo checkouts.

### DIFF
--- a/bin/pyenv-installer
+++ b/bin/pyenv-installer
@@ -22,7 +22,7 @@ colorize() {
 }
 
 checkout() {
-  [ -d "$2" ] || git clone "$1" "$2"
+  [ -d "$2" ] || git clone --depth 1 "$1" "$2"
 }
 
 if ! command -v git 1>/dev/null 2>&1; then


### PR DESCRIPTION
Fixes #34.

Does pyenv need the `~/.pyenv` directory to be a git checkout, or could we just download https://github.com/yyuu/pyenv-installer/archive/master.tar.gz instead? That would be an even better solution than this PR.